### PR TITLE
Add Playwright recorder helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # automationtest
+
+This repository contains helper scripts for recording browser interactions with Playwright.
+
+## Setup
+
+Install Playwright and its browsers:
+
+```bash
+pip install playwright
+playwright install
+```
+
+## Recording actions
+
+Use the recording script to launch the Playwright code generator for a URL:
+
+```bash
+python scripts/record_actions.py https://example.com
+```
+
+After recording your interactions, save the generated test file.
+

--- a/scripts/record_actions.py
+++ b/scripts/record_actions.py
@@ -1,0 +1,15 @@
+import subprocess
+import sys
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: python scripts/record_actions.py <url>")
+        sys.exit(1)
+    url = sys.argv[1]
+    # Launch Playwright codegen for the provided URL
+    subprocess.run(["playwright", "codegen", url], check=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a script to record Playwright actions
- document setup and usage

## Testing
- `python -m py_compile scripts/record_actions.py`

------
https://chatgpt.com/codex/tasks/task_e_684d1d9923848324bb07c463f5166362